### PR TITLE
docker: Generate config file in the spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM nginx:1.10
-
-ADD default.tmpl /etc/nginx/conf.d/default.tmpl
-
-CMD ["/bin/bash", "-c", "envsubst < /etc/nginx/conf.d/default.tmpl > /etc/nginx/conf.d/default.conf \
-    && nginx -g 'daemon off;'"]

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-var image = "quilt/nginx"
+var image = "nginx:1.10"
 
 exports.New = function(port) {
     port = port || 80;
@@ -8,11 +8,25 @@ exports.New = function(port) {
 
     // Create a Nginx Docker container, encapsulating it within the service "web_tier".
     var webTier = new Service("web_tier", [
-            new Container(image).withEnv({
-                PORT: port.toString(),
+            new Container(image).withFiles({
+                "/etc/nginx/conf.d/default.conf": buildConfig(port),
             })
     ]);
     publicInternet.connect(port, webTier);
 
     return webTier;
+}
+
+function buildConfig(port) {
+    var template = read("./default.tmpl");
+    return applyTemplate(template, {"port": port});
+}
+
+// applyTemplate replaces the keys defined by `vars` with their corresponding
+// values in `template`. A variable is denoted in the template using {{key}}.
+function applyTemplate(template, vars) {
+    for (k in vars) {
+        template = template.replace("{{"+k+"}}", vars[k]);
+    }
+    return template;
 }

--- a/default.tmpl
+++ b/default.tmpl
@@ -1,5 +1,5 @@
 server {
-    listen       ${PORT};
+    listen       {{port}};
     server_name  localhost;
 
     location / {


### PR DESCRIPTION
This patch removes our custom Dockerfile by generating the config file
in the Javascript, rather than when the container boots.

The `quilt/nginx` Dockerhub repo should be removed once this is merged.