### PR TITLE
node: Migrate to Node.js (RFC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -1,4 +1,11 @@
-var image = "nginx:1.10"
+const {
+		Service,
+		Container,
+		read,
+		publicInternet,
+} = require('@quilt/core');
+
+const image = "nginx:1.10"
 
 exports.New = function(port) {
     port = port || 80;
@@ -25,7 +32,7 @@ function buildConfig(port) {
 // applyTemplate replaces the keys defined by `vars` with their corresponding
 // values in `template`. A variable is denoted in the template using {{key}}.
 function applyTemplate(template, vars) {
-    for (k in vars) {
+    for (let k in vars) {
         template = template.replace("{{"+k+"}}", vars[k]);
     }
     return template;

--- a/main.js
+++ b/main.js
@@ -1,9 +1,14 @@
-var app = require("./app");
+const {
+		createDeployment,
+		Machine,
+		githubKeys,
+} = require('@quilt/core');
+const app = require('./app');
 
-var deployment = createDeployment({});
+const deployment = createDeployment({});
 
 // Setup the infrastructure.
-var baseMachine = new Machine({
+const baseMachine = new Machine({
     provider: "Amazon",
     // Replace with your GitHub username to allow logging into machines.
     // sshKeys: githubKeys("CHANGE_ME"),

--- a/package.json
+++ b/package.json
@@ -1,3 +1,11 @@
 {
-    "main": "./app.js"
+  "name": "@quilt/nginx",
+  "version": "0.0.0",
+  "main": "./app.js",
+  "description": "PLACEHOLDER",
+  "repository": "quilt/nginx",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/core": "*"
+  }
 }


### PR DESCRIPTION
This patch moves this spec to use Node.js.

This PR was created for demo purposes to show how new specs would
look in Node.js. Since we don't have our main Quilt repo on the npm registry
yet, you'll need to `npm link` it into this repo to run this spec.

This accompanies quilt/quilt#845