### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -1,3 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+const {Service, Container, publicInternet} = require('@quilt/quilt');
+
 var image = "nginx:1.10"
 
 exports.New = function(port) {
@@ -18,7 +22,7 @@ exports.New = function(port) {
 }
 
 function buildConfig(port) {
-    var template = read("./default.tmpl");
+    var template = fs.readFileSync(path.join(__dirname, "default.tmpl"), {encoding: 'utf8'});
     return applyTemplate(template, {"port": port});
 }
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-var app = require("./app");
+const {createDeployment, Machine, githubKeys} = require('@quilt/quilt');
+var app = require('./app');
 
 var deployment = createDeployment({});
 

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./app.js"
+  "name": "@quilt/nginx",
+  "version": "0.0.1",
+  "main": "./app.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.