### PR TITLE
docker: Remove Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-REPO = quilt/nginx
-
-all: build-image
-
-build-image:
-	docker build -t $(REPO) .
-
-push-image: build-image
-	docker push $(REPO)


### PR DESCRIPTION
A previous commit changed this repo to generate the config
file in the spec, which meant we don't need a special Docker
image, and the functionality in the Makefile (to build the docker
image) isn't necesary.